### PR TITLE
use lowercase windows.h for easier cross compile

### DIFF
--- a/src/Tools/system_functions.cpp
+++ b/src/Tools/system_functions.cpp
@@ -11,7 +11,7 @@
 #elif defined(__APPLE__) || defined(__MACH__)
 #include <mach-o/dyld.h>
 #elif defined(_WIN32) || defined(_WIN64)
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #include <cstdio>


### PR DESCRIPTION
The mingw compiler, which can be used to cross compile from linux to windows, provides only a lower case windows.h file. Changing streampu to include only the lower case version will also work on windows,, since the file system on windows does not depend on case.